### PR TITLE
(WP-1318) Add Local servertype

### DIFF
--- a/config.go
+++ b/config.go
@@ -64,6 +64,8 @@ func (c *BaseConfig) SetServerType(envServerType string) {
 		c.ServerType = LiveTest
 	case "uat":
 		c.ServerType = UAT
+	case "local":
+		c.ServerType = Local
 	default:
 		c.ServerType = Development
 	}
@@ -99,6 +101,8 @@ func ReadConfig(config interface{}, envServerType string, configPathBuilder func
 		variantConfigPaths = []string{"config-uat.json"}
 	case LiveTest:
 		variantConfigPaths = []string{"config-livetest.json"}
+	case Local:
+		variantConfigPaths = []string{"config-local.json"}
 	}
 
 	var configReadError error

--- a/service.go
+++ b/service.go
@@ -28,10 +28,11 @@ const (
 	Development
 	LiveTest
 	UAT
+	Local
 )
 
 func (s ServerType) String() string {
-	return [...]string{"Production", "Staging", "Development", "LiveTest", "UAT"}[s]
+	return [...]string{"Production", "Staging", "Development", "LiveTest", "UAT", "Local"}[s]
 }
 
 type LogType int


### PR DESCRIPTION
This is to allow the Adapptor services to be run with a local config as opposed to the dev environment