### PR TITLE
Add service name configuration, user property logging, and formatted …

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,26 +12,19 @@ type GoogleConfig struct {
 }
 
 type BaseConfig struct {
-	ServerType ServerType
-	ConfigName string
-	Version    string
-	Google     GoogleConfig
-	SentryDsn  *string
+	ServiceName string
+	ServerType  ServerType
+	ConfigName  string
+	Version     string
+	Google      GoogleConfig
+	SentryDsn   *string
 }
 
 type IBaseConfig interface {
-	GetVersionString() string
-	SetServerType(string)
 	GetServerType() ServerType
+	SetServerType(string)
+	GetVersionString() string
 	IsProductionServer() bool
-}
-
-func (c *BaseConfig) GetVersionString() string {
-	if c == nil {
-		return ""
-	} else {
-		return c.Version + "-" + c.ConfigName
-	}
 }
 
 func (c *BaseConfig) GetServerType() ServerType {
@@ -40,22 +33,6 @@ func (c *BaseConfig) GetServerType() ServerType {
 	} else {
 		return c.ServerType
 	}
-}
-
-func (c *BaseConfig) GetSentryDsn() *string {
-	if c == nil {
-		return nil
-	}
-	return c.SentryDsn
-}
-
-func (c *BaseConfig) IsProductionServer() bool {
-	switch c.ServerType {
-	case Production, LiveTest:
-		return true
-	}
-
-	return false
 }
 
 func (c *BaseConfig) SetServerType(envServerType string) {
@@ -77,6 +54,23 @@ func (c *BaseConfig) SetServerType(envServerType string) {
 	default:
 		c.ServerType = Development
 	}
+}
+
+func (c *BaseConfig) GetVersionString() string {
+	if c == nil {
+		return ""
+	} else {
+		return c.Version + "-" + c.ConfigName
+	}
+}
+
+func (c *BaseConfig) IsProductionServer() bool {
+	switch c.ServerType {
+	case Production, LiveTest:
+		return true
+	}
+
+	return false
 }
 
 func ReadConfig(config interface{}, envServerType string, configPathBuilder func(string) string) error {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,13 @@
-## 2.0.0 18 May 2023
+## 2.0.0 31 May 2023
 
 - Refactored support for multiple log sinks, and added support for Sentry logging
+- All loggers accept a list of user properties to log (e.g., email, user ID)
 - Breaking changes:
+- Service configuration now requires a `ServiceName` property, which is logged as a Sentry event tag
 - Log functions have been moved from `service` to the `log` package
 - Logs of the form `service.Log.[Level](...)` must be moved to `log.Log(log.[Level], ...)`
 - The Firebase client constructor signature has changed, and now explicitly takes a firebase config struct and credentials file
+- Add required `serviceName` field to base configuration
 
 ## 1.0.8 14 Feb 2023
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -12,7 +12,16 @@ type LoggerThatClosesWithError struct {
 }
 
 func (l *LoggerThatClosesWithError) SetMinimumLevel(logLevel LogLevel) {}
+func (l *LoggerThatClosesWithError) GetMinimumLevel() LogLevel {
+	return Debug
+}
+func (l *LoggerThatClosesWithError) SetUserPropertiesToLog(userPropertiesToLog *[]UserProperty) {}
+func (l *LoggerThatClosesWithError) GetUserPropertiesToLog() *[]UserProperty                    { return nil }
 func (l *LoggerThatClosesWithError) Log(level LogLevel, message string, err error, ctx context.Context) {
+}
+func (l *LoggerThatClosesWithError) Logf(level LogLevel, err error, ctx context.Context, format string, args ...interface{}) {
+}
+func (l *LoggerThatClosesWithError) Logln(level LogLevel, err error, ctx context.Context, args ...interface{}) {
 }
 func (l *LoggerThatClosesWithError) Close(timeout time.Duration) error {
 	// Sleep for half the timeout, then error

--- a/log/logger.go
+++ b/log/logger.go
@@ -12,7 +12,7 @@ import (
 // Singleton LoggerSet
 var loggerSet = NewLoggerSet(Info)
 
-// A public reference to the singleton LogSet if required for injection
+// A public reference to the singleton LoggerSet if required for injection
 var L = loggerSet
 
 // A simple logging interface
@@ -25,8 +25,23 @@ type Logger interface {
 	// ctx: An optional context to log with the message.
 	Log(level LogLevel, message string, err error, ctx context.Context)
 
+	// Logf logs a formatted message with the specified log level and error (if applicable), along with the provided context.
+	Logf(level LogLevel, err error, ctx context.Context, format string, args ...interface{})
+
+	// Logln logs a message with the specified log level and error (if applicable), along with the provided context.
+	Logln(level LogLevel, err error, ctx context.Context, args ...interface{})
+
 	// SetMinimumLevel sets the minimum log level; logs below this level will be ignored
 	SetMinimumLevel(level LogLevel)
+
+	// GetMinimumLevel returns the most recently set minimum log level
+	GetMinimumLevel() LogLevel
+
+	// SetUserPropertiesToLog sets the user properties to log
+	SetUserPropertiesToLog(userPropertiesToLog *[]UserProperty)
+
+	// GetUserPropertiesToLog returns the most recently set user properties to log
+	GetUserPropertiesToLog() *[]UserProperty
 
 	// If applicable to the logger type, closes the logger with a timeout to flush all buffered log entries before returning
 	Close(timeout time.Duration) error
@@ -38,13 +53,50 @@ func AddLogger(logger Logger) {
 
 // Convenience function to set the minimum log level for all
 // current log sinks.
-// Log sinks added after this call will not be affected
+//
+// Note: Log sinks added after this call will not be affected
 func SetMinimumLevel(logLevel LogLevel) {
 	loggerSet.SetMinimumLevel(logLevel)
 }
 
+// Convenience function to get the minimum log level for all
+// current log sinks.
+//
+// Note: Log sinks added after the most recent call of SetMinimumLevel
+// can have different minimum log levels.
+func GetMinimumLevel() LogLevel {
+	return loggerSet.GetMinimumLevel()
+}
+
+// Convenience function to set the user properties to log for all
+// current log sinks.
+//
+// Note: Log sinks added after this call will not be affected
+func SetUserPropertiesToLog(userPropertiesToLog *[]UserProperty) {
+	loggerSet.userPropertiesToLog = userPropertiesToLog
+
+	for _, logger := range loggerSet.loggers {
+		logger.SetUserPropertiesToLog(userPropertiesToLog)
+	}
+}
+
+// Convenience function to get the user properties to log
+// for all current log sinks
+//
+// Note: Log sinks added after the most recent call of SetUserPropertiesToLog
+// can have different values.
+func GetUserPropertiesToLog() *[]UserProperty { return loggerSet.userPropertiesToLog }
+
 func Log(level LogLevel, message string, err error, ctx context.Context) {
 	loggerSet.Log(level, message, err, ctx)
+}
+
+func Logf(level LogLevel, err error, ctx context.Context, format string, args ...interface{}) {
+	loggerSet.Logf(level, err, ctx, format, args...)
+}
+
+func Logln(level LogLevel, err error, ctx context.Context, args ...interface{}) {
+	loggerSet.Logln(level, err, ctx, args...)
 }
 
 func Close(timeout time.Duration) error {

--- a/log/logger_set.go
+++ b/log/logger_set.go
@@ -9,7 +9,9 @@ import (
 // A set of log sinks (e.g., stdout, file, Sentry, etc.)
 // Logs are sent to all sinks
 type LoggerSet struct {
-	loggers []Logger
+	loggers             []Logger
+	minimumLevel        LogLevel
+	userPropertiesToLog *[]UserProperty
 }
 
 // Create a new log set, with the standard logger
@@ -28,16 +30,58 @@ func (l *LoggerSet) AddLogger(logger Logger) {
 
 // Convenience function to set the minimum log level for all
 // current log sinks.
-// Log sinks added after this call will not be affected
+//
+// Note: Log sinks added after this call will not be affected
 func (l *LoggerSet) SetMinimumLevel(logLevel LogLevel) {
 	for _, logger := range l.loggers {
 		logger.SetMinimumLevel(logLevel)
 	}
+	l.minimumLevel = logLevel
 }
+
+// Convenience function to get the minimum log level
+// for all current log sinks
+//
+// Note: Log sinks added after the most recent call of SetMinimumLevel
+// can have different minimum log levels.
+func (l *LoggerSet) GetMinimumLevel() LogLevel {
+	return l.minimumLevel
+}
+
+// Convenience function to set the user properties to log for all
+// current log sinks.
+//
+// Note: Log sinks added after this call will not be affected
+func (l *LoggerSet) SetUserPropertiesToLog(userPropertiesToLog *[]UserProperty) {
+	l.userPropertiesToLog = userPropertiesToLog
+
+	for _, logger := range l.loggers {
+		logger.SetUserPropertiesToLog(userPropertiesToLog)
+	}
+}
+
+// Convenience function to get the user properties to log
+// for all current log sinks
+//
+// Note: Log sinks added after the most recent call of SetUserPropertiesToLog
+// can have different values.
+func (l *LoggerSet) GetUserPropertiesToLog() *[]UserProperty { return l.userPropertiesToLog }
 
 func (l *LoggerSet) Log(level LogLevel, message string, err error, ctx context.Context) {
 	for _, logger := range l.loggers {
 		logger.Log(level, message, err, ctx)
+	}
+}
+
+func (l *LoggerSet) Logf(level LogLevel, err error, ctx context.Context, format string, args ...interface{}) {
+	for _, logger := range l.loggers {
+		logger.Logf(level, err, ctx, format, args...)
+	}
+}
+
+func (l *LoggerSet) Logln(level LogLevel, err error, ctx context.Context, args ...interface{}) {
+	for _, logger := range l.loggers {
+		logger.Logln(level, err, ctx, args...)
 	}
 }
 

--- a/log/user.go
+++ b/log/user.go
@@ -1,0 +1,83 @@
+package log
+
+import (
+	"context"
+	"strings"
+)
+
+// Key for the map of all user properties added to a context
+const UserPropertiesKey = "user"
+
+type UserProperty string
+
+// The following keys are used to add user properties (as a map of UserProperty -> string) to a context for use by loggers
+const (
+	// Key for user id added to the context in the user properties map
+	UserPropertyId UserProperty = "userId"
+	// Key for user email added to the context in the user properties map
+	UserPropertyEmail UserProperty = "email"
+	// Key for user name added to the context in the user properties map
+	UserPropertyName UserProperty = "userName"
+)
+
+var UserProperties = [...]UserProperty{UserPropertyId, UserPropertyEmail, UserPropertyName}
+
+// ContainsUserProperty checks if a UserProperty value exists in an array of UserProperty.
+//
+// It takes in two parameters: an array of UserProperty and a UserProperty value to search for.
+// It returns a boolean indicating whether or not the value was found in the array.
+func ContainsUserProperty(array []UserProperty, value UserProperty) bool {
+	for _, a := range array {
+		if a == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetUserPropertiesMap returns the user properties map from the given context, or nil if no user properties are found.
+func GetUserPropertiesMap(ctx context.Context) *map[UserProperty]string {
+	if ctx != nil {
+		if userProperties := ctx.Value(UserPropertiesKey); userProperties != nil {
+			if userPropertiesMap, ok := userProperties.(*map[UserProperty]string); ok {
+				return userPropertiesMap
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetUserPropertiesString returns a string that contains comma-separated user properties
+// that are specified in the given context and userPropertiesToLog slice.
+//
+// ctx is the context that contains user properties information. userPropertiesToLog
+// is a pointer to a slice of UserProperty that specifies which user properties to log.
+// A pointer to a string is returned that contains comma-separated user properties.
+// If no user properties are specified or the context is nil, nil is returned.
+func GetUserPropertiesString(ctx context.Context, userPropertiesToLog *[]UserProperty) *string {
+	haveUserToLog := false
+
+	if ctx != nil && userPropertiesToLog != nil && len(*userPropertiesToLog) > 0 {
+		if userProperties := ctx.Value(UserPropertiesKey); userProperties != nil {
+			if userPropertiesMap, ok := userProperties.(*map[UserProperty]string); ok {
+				tempResult := []string{}
+
+				for _, userProperty := range *userPropertiesToLog {
+					if userPropertyValue, ok := (*userPropertiesMap)[userProperty]; ok {
+						tempResult = append(tempResult, userPropertyValue)
+						haveUserToLog = true
+					}
+				}
+
+				if haveUserToLog {
+					result := strings.Join(tempResult, ", ")
+					return &result
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
…log convenience functions

The migration of existing logs to v2 is something like:

For each error level:
Search & Replace: "service.Log.[Level].Printf(" -> "log.Logf(log.[Level], nil, nil,"
Search & Replace: "service.Log.[Level].Println(" -> "log.Logln(log.{Level], nil, nil,"

Optionally, then search for ", nil, nil," and add any errors or context if available.