### PR TITLE
Version bump to 2.0.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1 31 May 2023
+
+- No code changes; version bump to fix moved v2.0.0 commit
+
 ## 2.0.0 31 May 2023
 
 - Refactored support for multiple log sinks, and added support for Sentry logging


### PR DESCRIPTION
Go doesn't appear to be picking up the updated tag for 2.0.0 (which is probably fair enough).