### PR TITLE
Fix standard_logger file and line number reference

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.3 16 Apr 2025
+- Fix standard_logger.go file and line number reference on all log messages
+
 ## 2.0.2 30 Jun 2023
 
 - Add Fatal log level

--- a/log/standard_logger.go
+++ b/log/standard_logger.go
@@ -44,25 +44,24 @@ func (l *StandardLogger) SetUserPropertiesToLog(userPropertiesToLog *[]UserPrope
 
 func (l *StandardLogger) GetUserPropertiesToLog() *[]UserProperty { return l.userPropertiesToLog }
 
+// logInternal - all public log functions should call this after checking the minimum level
 func (l *StandardLogger) logInternal(level LogLevel, message string, err error, ctx context.Context) {
-	if level >= l.minimumLevel {
-		// Get the calling function skipping 4 frames so we can print the actual caller
-		if _, file, line, ok := runtime.Caller(4); ok {
-			lastSlash := strings.LastIndex(file, "/")
-			fileName := file[lastSlash+1:]
-			message = fmt.Sprintf("%s:%d: %s", fileName, line, message)
-		}
+	// Get the calling function skipping 4 frames so we can print the actual caller
+	if _, file, line, ok := runtime.Caller(4); ok {
+		lastSlash := strings.LastIndex(file, "/")
+		fileName := file[lastSlash+1:]
+		message = fmt.Sprintf("%s:%d: %s", fileName, line, message)
+	}
 
-		userProperties := GetUserPropertiesString(ctx, l.userPropertiesToLog)
-		if userProperties != nil {
-			message = fmt.Sprintf("%s (%s)", message, *userProperties)
-		}
+	userProperties := GetUserPropertiesString(ctx, l.userPropertiesToLog)
+	if userProperties != nil {
+		message = fmt.Sprintf("%s (%s)", message, *userProperties)
+	}
 
-		if err == nil {
-			l.levelLoggers[level].Println(message)
-		} else {
-			l.levelLoggers[level].Printf("%s, %+v\n", message, err)
-		}
+	if err == nil {
+		l.levelLoggers[level].Println(message)
+	} else {
+		l.levelLoggers[level].Printf("%s, %+v\n", message, err)
 	}
 }
 

--- a/log/standard_logger.go
+++ b/log/standard_logger.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strings"
 	"time"
 )
 
@@ -19,7 +21,7 @@ func NewStandardLogger(minimumLevel LogLevel) *StandardLogger {
 	// Create level loggers
 	levelLoggers := make(map[LogLevel]*log.Logger)
 	for _, logLevel := range LogLevels {
-		levelLoggers[logLevel] = log.New(os.Stderr, fmt.Sprintf("%s: ", logLevel.String()), log.Ldate|log.Ltime|log.Lshortfile)
+		levelLoggers[logLevel] = log.New(os.Stderr, fmt.Sprintf("%s: ", logLevel.String()), log.Ldate|log.Ltime)
 	}
 
 	return &StandardLogger{
@@ -42,8 +44,15 @@ func (l *StandardLogger) SetUserPropertiesToLog(userPropertiesToLog *[]UserPrope
 
 func (l *StandardLogger) GetUserPropertiesToLog() *[]UserProperty { return l.userPropertiesToLog }
 
-func (l *StandardLogger) Log(level LogLevel, message string, err error, ctx context.Context) {
+func (l *StandardLogger) logInternal(level LogLevel, message string, err error, ctx context.Context) {
 	if level >= l.minimumLevel {
+		// Get the calling function skipping 4 frames so we can print the actual caller
+		if _, file, line, ok := runtime.Caller(4); ok {
+			lastSlash := strings.LastIndex(file, "/")
+			fileName := file[lastSlash+1:]
+			message = fmt.Sprintf("%s:%d: %s", fileName, line, message)
+		}
+
 		userProperties := GetUserPropertiesString(ctx, l.userPropertiesToLog)
 		if userProperties != nil {
 			message = fmt.Sprintf("%s (%s)", message, *userProperties)
@@ -57,9 +66,15 @@ func (l *StandardLogger) Log(level LogLevel, message string, err error, ctx cont
 	}
 }
 
+func (l *StandardLogger) Log(level LogLevel, message string, err error, ctx context.Context) {
+	if level >= l.minimumLevel {
+		l.logInternal(level, message, err, ctx)
+	}
+}
+
 func (l *StandardLogger) Logf(level LogLevel, err error, ctx context.Context, format string, args ...interface{}) {
 	if level >= l.minimumLevel {
-		l.Log(level, fmt.Sprintf(format, args...), err, ctx)
+		l.logInternal(level, fmt.Sprintf(format, args...), err, ctx)
 	}
 }
 
@@ -72,7 +87,7 @@ func (l *StandardLogger) Logln(level LogLevel, err error, ctx context.Context, a
 			message = message[:len(message)-1]
 		}
 
-		l.Log(level, message, err, ctx)
+		l.logInternal(level, message, err, ctx)
 	}
 }
 


### PR DESCRIPTION
Currently all log messages have standard_logger.go:53 in the prefix. This change removes the default prefix and adds a custom extra prefix with the actual calling function.
Before: `INFO: 2025/04/15 15:11:23 standard_logger.go:53: initLogging started`
After : `INFO: 2025/04/15 15:11:23 shared.go:135: initLogging started`